### PR TITLE
Update font styling to address CSS custom property issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,14 +159,17 @@ You can also use a global `<template>` tag to set these attributes. If any local
 The component is packaged with base styles, which can be adjusted as seen fit by modifying CSS custom properties:
 | Syntax | Description | Default Value |
 | ----------- | ----------- | --------------- |
-| `--feedback-component-font-size` | Font size for the component's text. | 1.125rem
-| `--feedback-component-font-weight` | Font weight for the component's text. | 400
-| `--feedback-component-font-family` | Font family for the component's text. | Arial, sans-serif
-| `--feedback-component-font-color` | Font color for the component's text. | #69757a
-| `--feedback-component-button-size` | Width & height of each option button. | 2rem
 | `--feedback-component-button-background-color` | Background color of each option button. | #e8eced
-| `--feedback-component-icon-size` | Width & height of each option button. | 1rem
+| `--feedback-component-button-size` | Width & height of each option button. | 2rem
 | `--feedback-component-icon-color` | Color of the icon within each option button. | #69757a
+| `--feedback-component-icon-size` | Width & height of each option button. | 1rem
+| `--feedback-component-font-color` | Font color for the component's text. | #69757a
+| `--feedback-component-font-family` | Font family for the component's text. | Arial, sans-serif
+| `--feedback-component-font-size` | Font size for the component's text. | 1.125rem
+| `--feedback-component-font-style` | Font style for the component's text. | normal
+| `--feedback-component-font-variant` | Font variant for the component's text. | normal
+| `--feedback-component-font-weight` | Font weight for the component's text. | 400
+| `--feedback-component-line-height` | Line height for the component's text. | normal
 
 ## Browser Support
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ramseyinhouse/feedback-component",
   "description": "A native web component for collecting quick user feedback.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "source": "src/index.js",
   "main": "dist/feedback-component.min.modern.js",
   "license": "GPL-3.0",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,9 +3,12 @@
   position: relative;
   align-items: center;
   color: var(--feedback-component-font-color, #69757a);
-  font: normal normal var(--feedback-component-font-weight, 400)
-    var(--feedback-component-font-size, 1.125rem) / normal
-    var(--feedback-component-font-family, inherit);
+  font-style: var(--feedback-component-font-style, normal);
+  font-variant: var(--feedback-component-font-variant, normal);
+  font-weight: var(--feedback-component-font-weight, normal);
+  font-size: var(--feedback-component-font-size, 1.125rem);
+  line-height: var(--feedback-component-line-height, normal);
+  font-family: var(--feedback-component-font-family, inherit);
 
   ::slotted(*) {
     display: unset !important;


### PR DESCRIPTION
## Description of Proposed Changes
Due to the shorthand `font` property that was being used to set all font-related styles, the CSS custom properties set by consuming applications weren't working, because a sole `font` property has a lesser specificity than `font-size`, `font-family`, and other more explicit properties. 

This PR expands that single `font` property into the individual properties that compose it. 

## Related Issue (if applicable)
Fixes #9.
